### PR TITLE
Testing Optimization Approaches

### DIFF
--- a/tests/test_diff_tables.py
+++ b/tests/test_diff_tables.py
@@ -796,7 +796,7 @@ class TestInfoTree(DiffTestCase):
             for child in diff_res.info_tree.to_dict()["children"]:
                 segments.append(child["info"]["rowcounts"])
             self.assertEqual(
-                method_calls_count.get("count"), 32, msg=f"method called: {method_calls_count}, info={segments}"
+                method_calls_count.get("count"), 64, msg=f"method called: {method_calls_count}, info={segments}"
             )
 
 


### PR DESCRIPTION
- test counting rows first, skip checksum if counts do not match
- test only counting rows, no checksuming
- test counting rows or/and checksuming w/out local diff
- test various combinations of above
- intersept methoid calls to figure out Big-O(n rows) for data-diff algorithm

This is not a production ready code, but it does work well enough to be able to test different approaches.

How to run a  a test to replicate results (add other flag env variables)
```
LOG_LEVEL=INFO python -m unittest -v -k count_first_optimization tests/test_diff_tables.py
```

With defaults, here is the methods calls summary from unit test that checks two table segments `t1(1..1000)` and `t2(1..2000)`

Defaults
``` 
method called: {'with_schema': 1, 'count': 64, 'count_and_checksum': 32, 'get_values': 32}
```
With auto bisection factor enabled
```
 method called: {'with_schema': 1, 'count': 32, 'count_and_checksum': 2, 'get_values': 16}
```

With 'master' branch version of `data_diff/hashdiff_tables.py`:
```
method called: {'with_schema': 1, 'count_and_checksum': 64, 'get_values': 32}
```

Also, testing "only counts" scenario when we only check row counts in segment - it is, as expected significantly faster
```
23:15:10 INFO     Duration: 24.06 seconds.    <--- only counts
# vs 
14:18:11 INFO     Duration: 523.09 seconds.   
```

I have notes about algorithmic complexity, i.e. big-O notation of the algorithm, that I'd like to post on Slack