### PR TITLE
DBE-3091 Use real segment size for calculating bisection factor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     #     run: "gcloud config configurations list"
 
       - name: "Install BigQuery for Python"
-        run: poetry add google-cloud-bigquery
+        run: poetry add "google-cloud-bigquery<3.0.0"
 
       # BigQuery end
 

--- a/data_diff/diff_tables.py
+++ b/data_diff/diff_tables.py
@@ -391,10 +391,10 @@ class TableDiffer(ThreadBase, ABC):
         assert table1.is_bounded and table2.is_bounded
 
         # Choose evenly spaced checkpoints (according to min_key and max_key)
-        biggest_table = max(table1, table2, key=methodcaller("approximate_size"))
+        biggest_table = max(table1, table2, key=methodcaller("count"))
         logger.info(f"Diff segments level: {level}")
         if self.auto_bisection_factor:
-            self.bisection_factor = self.calculate_bisection_factor(biggest_table.approximate_size())
+            self.bisection_factor = self.calculate_bisection_factor(biggest_table.count())
             logger.info(
                 f"Automatically setting bisection_factor, max_rows: {max_rows}, self.bisection_factor: {self.bisection_factor}"
             )


### PR DESCRIPTION
Fixes #25 

currently data-diff uses `TableSegment.approximate_size()` to get a sense of data set size it is about to check. approximate_size() in turn uses max_key - min_key logic to calculate segment size. While this works well for most of the tables, it does not work ~at all~ very well for a relatively common case where TableSegment is [rows updated since time X].   
given we update a few user ids in User table, when of the user ids is the earliest user with id close to 1, approximate_size() returns ~ total record count for a table, when the actual size of [rows updated since time X] is just a few rows.

The fix is to use  the actual row count for TableSegment.