### PR TITLE
Fix MySQL CI startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
 
     mysql:
       container_name: dd-mysql
-      image: mysql:lts-oracle   # 8.4.x
+      image: mysql:8.4.8-oracle
       # fsync less aggressively for insertion perf for test setup
       command: >
         --mysql-native-password=ON

--- a/tests/waiting_for_stack_up.sh
+++ b/tests/waiting_for_stack_up.sh
@@ -1,4 +1,29 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -o nounset -o pipefail -o errexit
+
+wait_for_mysql() {
+    local retries=60
+
+    echo "Check MySQL DB running..."
+    until docker exec dd-mysql sh -c 'mysql --protocol=tcp -h 127.0.0.1 -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" -e "SELECT 1" >/dev/null 2>&1'
+    do
+        retries=$((retries - 1))
+        if [ "$retries" -le 0 ]
+        then
+            echo "MySQL DB did not become ready in time"
+            docker ps --filter "name=dd-mysql"
+            docker logs dd-mysql
+            exit 1
+        fi
+
+        echo "Waiting for MySQL DB starting..."
+        sleep 5
+    done
+
+    echo "MySQL DB is ready"
+}
+
+wait_for_mysql
 
 if [ -n "${DATADIFF_VERTICA_URI:-}" ]
     then


### PR DESCRIPTION
## Summary
- Pin the MySQL Docker image to 8.4.8 instead of the moving lts-oracle tag, which now resolves to MySQL 9.7 in CI
- Wait for the MySQL container to accept a real login query before running the test suite
- Print MySQL container diagnostics if readiness times out

## Verification
- bash -n tests/waiting_for_stack_up.sh
- docker-compose config
- ./tests/waiting_for_stack_up.sh against a local running dd-mysql container

Fixes #45